### PR TITLE
Replace deprecated render text:

### DIFF
--- a/app/controllers/w000ts_controller.rb
+++ b/app/controllers/w000ts_controller.rb
@@ -259,7 +259,7 @@ class W000tsController < ApplicationController
       format.json { render :create, locals: { w000t: @w000t }, status: status }
       format.js   { render :create, locals: { w000t: @w000t } }
       format.html { redirect_back fallback_location: '/', notice: "W000t created #{w000t_url}" }
-      format.text { render text: w000t_url }
+      format.text { render plain: w000t_url }
     end
   end
 

--- a/spec/controllers/w000ts_controller_spec.rb
+++ b/spec/controllers/w000ts_controller_spec.rb
@@ -151,6 +151,20 @@ JSON
     assert_response :success
   end
 
+  it 'should create a w000t as text' do
+    url = 'http://google.fr/text'
+    expect do
+      post :create, params: {
+                      w000t: { long_url: url },
+                      user_id: @user.id
+                    },
+                    format: :text
+    end.to change { W000t.count }.by(1)
+    assert_response :success
+    w = W000t.find_by('url_info.url' => url)
+    expect(response.body).to match(w.short_url)
+  end
+
   it 'should get show on public w000t' do
     get :show, params: { short_url: @w000t.short_url }
     assert_response :success


### PR DESCRIPTION
Deprecated in rails 5.1 :
https://github.com/rails/rails/blob/v5.1.0.rc1/actionpack/CHANGELOG.md
Add test to check that creation with format text works